### PR TITLE
chore: enable All Contributors bot and add myself as contributor

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,26 @@
+{
+  "projectName": "MailMERN",
+  "projectOwner": "OPCODE-Open-Spring-Fest",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "SUJALGOYALL",
+      "name": "sujalgoyall",
+      "avatar_url": "https://avatars.githubusercontent.com/u/149406142?v=4",
+      "profile": "https://github.com/SUJALGOYALL",
+      "contributions": [
+        "code",
+        "doc"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7,
+  "linkToUsage": false
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # 💌 MERN Mass Email Sender & AI Auto-Responder
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 A full-stack **MERN Starter Project** for creating an **open-source email marketing platform** — similar to **AWeber** or **Mailchimp** — that can:
 - 📩 Send **mass emails** to large groups efficiently  
@@ -234,3 +237,24 @@ If you like this project:
 🚀 Contribute by raising PRs
 
 Together, let’s build an open-source AI-powered mass email platform!
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/SUJALGOYALL"><img src="https://avatars.githubusercontent.com/u/149406142?v=4?s=100" width="100px;" alt="sujalgoyall"/><br /><sub><b>sujalgoyall</b></sub></a><br /><a href="https://github.com/OPCODE-Open-Spring-Fest/MailMERN/commits?author=SUJALGOYALL" title="Code">💻</a> <a href="https://github.com/OPCODE-Open-Spring-Fest/MailMERN/commits?author=SUJALGOYALL" title="Documentation">📖</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!


### PR DESCRIPTION
# PR: Enable All Contributors Bot and Add Initial Contributor

## Description

This pull request **enables the All Contributors bot** for the MailMERN project and adds the initial contributor (`@sujalgoyall`).  

- Initializes `.all-contributorsrc` with the project configuration  
- Adds the contributors section and badge to `README.md`  
- Sets up the repository to allow future contributors to be automatically added via the bot  

---

## Semver Changes

- [x] Patch (bug fix, no new features)  
- [ ] Minor (new features, no breaking changes)  
- [ ] Major (breaking changes)  


---

## Issues

> Closes #18 

---

## How Contributors Can Add Themselves

Once this PR is merged, future contributors can be added in two ways:

1. **Via GitHub comment**:  
   Comment on a PR or Issue:  
   `@all-contributors please add @username for code, doc`  
   The bot will automatically create a PR to update the README.

2. **Via CLI on a fork**:  
   Contributors can run:  
   ```bash
   npx all-contributors add <their-github-username> <types>
   ```

   Then submit a PR from their fork. Once merged, the README will update automatically.

---

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md)  
- [x] I have added myself as an initial contributor  
- [x] The README now includes the contributors section and badge